### PR TITLE
Couple of updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 # AmiiboFlipperConverter
+
 Converts Amiibo .bins to a flipper compatible format
 
-Simply run `amiiboconvert.py` from the root directory to generate all amiibos within `raw_amiibos` to `nfcs`
+Run `amiiboconvert.py -i [filename].bin` to convert a single file.
 
-You can target a specific file by appending a path to the end of the call as such that `amiiboconvert.py *path to file*`
+To convert multiple files in a directory, run `amiiboconvert.py -i [input-folder] -o [output-folder]`.
+If you want to keep the folder structure, you would need to pass an extra `-t` argument, eg. `amiiboconvert.py -i [input-folder] -o [output-folder] -t`
 
-You can target a directory full of amiibos by passing a path such that `amiiboconvert.py *path to directory*`
-
-You can also use the amiibos i've generated already.
-
+To display help, run `amiiboconvert.py -h`
 
 The original code was created in the Flipper Discord by Friendartiste
 
@@ -16,6 +15,9 @@ The code was modified to run itteratively by Lamp
 
 I, VapidAnt, have modified the code to work in a variety of situations with a recursive function and have uploaded to github
 I believe this will make it easy to modify the code in the future and track changes over time.
+
+The code was modfied by Lanjelin to be able to handle .bin-files of varying sizes.
+Option to keep folder structure in the output folder added as well. Updated README/docs.
 
 If you have problems, please make an issue or ping me in the flipper discord.
 

--- a/src/amiiboconvert.py
+++ b/src/amiiboconvert.py
@@ -42,7 +42,8 @@ def convert(contents: bytes) -> Tuple[str, int]:
     When all's said and done, buffer contains text ready for writing to the end of a .nfc file.
 
     Also tracks and returns running page number, since that's also needed.
-    There should be exacly 135 pages for the .nfc not to fail on flipper
+    There should be exacly 135 pages for the .nfc not to fail on flipper,
+    due to NTAG215 beeing of 540 byte (135 pages) capacity.
     :param contents: byte array we're reading, from a .bin file
     :return: The full string of Pages, suitable for writing to a file
     """
@@ -232,13 +233,12 @@ def main():
                     f"{args.input_path} is a directory, but no output path given."
                 )
             )
+        logging.debug(f"Going to create output directory {args.output_path}")
+        os.makedirs(args.output_path, exist_ok=True)
     elif not os.path.exists(args.input_path):
         logging.exception(
             FileNotFoundError(f"{args.input_path} doesn't actually exist")
         )
-
-    logging.debug(f"Going to create output directory {args.output_path}")
-    os.makedirs(args.output_path, exist_ok=True)
 
     logging.debug(f"input: {args.input_path}, output: {args.output_path}")
     process(args.input_path, args.output_path, args.tree)

--- a/src/amiiboconvert.py
+++ b/src/amiiboconvert.py
@@ -162,6 +162,8 @@ def process(path: str, output_path: str, tree: bool):
         if tree:
             new_output_path = os.path.join(output_path, pathlib.Path(*pathlib.Path(path).parts[1:]))
             os.makedirs(new_output_path, exist_ok=True)
+        else:
+            new_output_path = output_path
         for filename in os.listdir(path):
             new_path = os.path.join(path, filename)
             logging.debug(f"Current file: {filename}; Current path: {new_path}")

--- a/src/amiiboconvert.py
+++ b/src/amiiboconvert.py
@@ -137,7 +137,7 @@ def convert_file(input_path: str, output_path: str):
     """
     input_extension = os.path.splitext(input_path)[1]
     if input_extension == ".bin":
-        logging.info(f"Writing: {input_path}")
+        logging.info(f"Writing: {os.path.join(output_path, os.path.splitext(os.path.basename(input_path))[0])}.nfc")
         with open(input_path, "rb") as file:
             contents = file.read()
             name = os.path.split(input_path)[1]

--- a/src/amiiboconvert.py
+++ b/src/amiiboconvert.py
@@ -149,7 +149,7 @@ def convert_file(input_path: str, output_path: str):
         logging.info(f"{input_path} doesn't seem like a relevant file, skipping")
 
 
-def process(path: str, output_path: str):
+def process(path: str, output_path: str, tree: bool):
     """
     Process an input file, or walk through an input directory and process every matching .bin file therein
     :param path: Path to a single file or a directory containing one or more .bin files
@@ -158,6 +158,9 @@ def process(path: str, output_path: str):
     if os.path.isfile(path):
         convert_file(path, output_path)
     else:
+        if tree:
+            output_path = os.path.join(output_path, pathlib.Path(*pathlib.Path(path).parts[1:]))
+            os.makedirs(output_path, exist_ok=True)
         for filename in os.listdir(path):
             new_path = os.path.join(path, filename)
             logging.debug(f"Current file: {filename}; Current path: {new_path}")
@@ -166,7 +169,7 @@ def process(path: str, output_path: str):
                 convert_file(new_path, output_path)
             else:
                 logging.debug(f"Recursing into: {new_path}")
-                process(new_path, output_path)
+                process(new_path, output_path, tree)
 
 
 def get_args():
@@ -192,6 +195,13 @@ def get_args():
         action="count",
         default=0,
         help="Show extra info: pass -v to see what's going on, pass -vv to get useful debug info",
+    )
+    parser.add_argument(
+        "-t",
+        "--tree",
+        action="store_true",
+        default=False,
+        help="Output the same folder structure as read from input folder",
     )
     args = parser.parse_args()
     if args.verbose >= 2:
@@ -228,7 +238,7 @@ def main():
     os.makedirs(args.output_path, exist_ok=True)
 
     logging.debug(f"input: {args.input_path}, output: {args.output_path}")
-    process(args.input_path, args.output_path)
+    process(args.input_path, args.output_path, args.tree)
 
 
 if __name__ == "__main__":

--- a/src/amiiboconvert.py
+++ b/src/amiiboconvert.py
@@ -1,12 +1,13 @@
 """
 amiiboconvert.py
-3/12/2022
+9/8/2022
 Modified Amiibo Flipper Conversion Code
 
 Original Code by Friendartiste
 Modified by Lamp
 Modified again by VapidAnt
 Modified and commented by bjschafer
+Modified yet again by Lanjelin
 
 Execute with python amiiboconvert -h to see options
 """
@@ -179,7 +180,7 @@ def get_args():
         "--input-path",
         required=True,
         type=pathlib.Path,
-        help="Single file or directory tree to convert",
+        help="Single file or directory tree to convert.",
     )
     parser.add_argument(
         "-o",
@@ -194,14 +195,14 @@ def get_args():
         "--verbose",
         action="count",
         default=0,
-        help="Show extra info: pass -v to see what's going on, pass -vv to get useful debug info",
+        help="Show extra info: pass -v to see what's going on, pass -vv to get useful debug info.",
     )
     parser.add_argument(
         "-t",
         "--tree",
         action="store_true",
         default=False,
-        help="Output the same folder structure as read from input folder",
+        help="Keep the same folder structure from the input folder to the output folder.",
     )
     args = parser.parse_args()
     if args.verbose >= 2:

--- a/src/amiiboconvert.py
+++ b/src/amiiboconvert.py
@@ -159,14 +159,14 @@ def process(path: str, output_path: str, tree: bool):
         convert_file(path, output_path)
     else:
         if tree:
-            output_path = os.path.join(output_path, pathlib.Path(*pathlib.Path(path).parts[1:]))
-            os.makedirs(output_path, exist_ok=True)
+            new_output_path = os.path.join(output_path, pathlib.Path(*pathlib.Path(path).parts[1:]))
+            os.makedirs(new_output_path, exist_ok=True)
         for filename in os.listdir(path):
             new_path = os.path.join(path, filename)
             logging.debug(f"Current file: {filename}; Current path: {new_path}")
 
             if os.path.isfile(new_path):
-                convert_file(new_path, output_path)
+                convert_file(new_path, new_output_path)
             else:
                 logging.debug(f"Recursing into: {new_path}")
                 process(new_path, output_path, tree)

--- a/src/amiiboconvert.py
+++ b/src/amiiboconvert.py
@@ -149,8 +149,8 @@ def process(path: str, output_path: str):
             new_path = os.path.join(path, filename)
             logging.debug(f"Current file: {filename}; Current path: {new_path}")
 
-            if os.path.isfile(path):
-                convert_file(path, output_path)
+            if os.path.isfile(new_path):
+                convert_file(new_path, output_path)
             else:
                 logging.debug(f"Recursing into: {new_path}")
                 process(new_path, output_path)


### PR DESCRIPTION
Added support for folder structure via `-t`-argument to resolve https://github.com/Lucaslhm/AmiiboFlipperConverter/issues/6

Forced the page length to 135, longer or shorter seems to always fail. This should fix https://github.com/Lucaslhm/AmiiboFlipperConverter/issues/5
Skipping anything after, padding zeroes where shorter. I've had success with generating working .nfc-files after this fix, where it previously failed. The .bins I've imported in [Ally](https://apps.apple.com/us/app/ally-collect-and-backup/id1517551768) that was shorter, is also 135 pages (appended zeroes at end) when written to NTAG215 and read by flipper, so it seems Ally also does something like this.
Edit: [NTAG capacity](https://www.shopnfc.com/en/content/6-nfc-tags-specs) is 540 bytes (135pages), so I suppose this is why the larger files fail.

Updated README.md to reflect on how the script is actually run, resolves https://github.com/Lucaslhm/AmiiboFlipperConverter/issues/2

Some minor tweaks and adjustments in text.

If you want to test for the page length, look for .bin-files that differs from 540bytes, so far I've seen 572bytes and 532bytes.
Look in the folders of `PowerUpBands`, `Power Pros`, `Mario Sports Superstars - Golf and Soccer`, `Box Boy`, `Diablo`, and some of the files in `Super Smash Bros` -if you're sitting on the same .bins as me. I've testet most of them in BOTW on my Switch.